### PR TITLE
Fix example builds

### DIFF
--- a/examples/esp/src/bin/light_eth.rs
+++ b/examples/esp/src/bin/light_eth.rs
@@ -31,7 +31,7 @@ use rs_matter_embassy::eth::{EmbassyEthMatterStack, EmbassyEthernet, Preexisting
 use rs_matter_embassy::matter::data_model::basic_info::BasicInfoConfig;
 use rs_matter_embassy::matter::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter_embassy::matter::data_model::objects::{
-    Async, Dataver, EmptyHandler, Endpoint, Node,
+    Async, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter_embassy::matter::data_model::on_off::{self, ClusterHandler as _};
 use rs_matter_embassy::matter::data_model::system_model::desc::{self, ClusterHandler as _};
@@ -121,15 +121,13 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            LIGHT_ENDPOINT_ID,
-            on_off::OnOffHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too
         // Just use the one that `rs-matter` provides out of the box
         .chain(
-            LIGHT_ENDPOINT_ID,
-            desc::DescHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(desc::DescHandler::CLUSTER.id)),
             Async(desc::DescHandler::new(Dataver::new_rand(stack.matter().rand())).adapt()),
         );
 

--- a/examples/esp/src/bin/light_eth.rs
+++ b/examples/esp/src/bin/light_eth.rs
@@ -121,7 +121,10 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
+            EpClMatcher::new(
+                Some(LIGHT_ENDPOINT_ID),
+                Some(on_off::OnOffHandler::CLUSTER.id),
+            ),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too

--- a/examples/esp/src/bin/light_eth2.rs
+++ b/examples/esp/src/bin/light_eth2.rs
@@ -164,7 +164,10 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
+            EpClMatcher::new(
+                Some(LIGHT_ENDPOINT_ID),
+                Some(on_off::OnOffHandler::CLUSTER.id),
+            ),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too

--- a/examples/esp/src/bin/light_eth2.rs
+++ b/examples/esp/src/bin/light_eth2.rs
@@ -29,7 +29,7 @@ use rs_matter_embassy::epoch::epoch;
 use rs_matter_embassy::matter::data_model::basic_info::BasicInfoConfig;
 use rs_matter_embassy::matter::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter_embassy::matter::data_model::objects::{
-    Async, Dataver, EmptyHandler, Endpoint, Node,
+    Async, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter_embassy::matter::data_model::on_off::{self, ClusterHandler as _};
 use rs_matter_embassy::matter::data_model::system_model::desc::{self, ClusterHandler as _};
@@ -164,15 +164,13 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            LIGHT_ENDPOINT_ID,
-            on_off::OnOffHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too
         // Just use the one that `rs-matter` provides out of the box
         .chain(
-            LIGHT_ENDPOINT_ID,
-            desc::DescHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(desc::DescHandler::CLUSTER.id)),
             Async(desc::DescHandler::new(Dataver::new_rand(stack.matter().rand())).adapt()),
         );
 

--- a/examples/esp/src/bin/light_thread.rs
+++ b/examples/esp/src/bin/light_thread.rs
@@ -128,7 +128,10 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
+            EpClMatcher::new(
+                Some(LIGHT_ENDPOINT_ID),
+                Some(on_off::OnOffHandler::CLUSTER.id),
+            ),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too

--- a/examples/esp/src/bin/light_thread.rs
+++ b/examples/esp/src/bin/light_thread.rs
@@ -29,7 +29,7 @@ use rs_matter_embassy::epoch::epoch;
 use rs_matter_embassy::matter::data_model::basic_info::BasicInfoConfig;
 use rs_matter_embassy::matter::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter_embassy::matter::data_model::objects::{
-    Async, Dataver, EmptyHandler, Endpoint, Node,
+    Async, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter_embassy::matter::data_model::on_off::{self, ClusterHandler as _};
 use rs_matter_embassy::matter::data_model::system_model::desc::{self, ClusterHandler as _};
@@ -128,15 +128,13 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            LIGHT_ENDPOINT_ID,
-            on_off::OnOffHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too
         // Just use the one that `rs-matter` provides out of the box
         .chain(
-            LIGHT_ENDPOINT_ID,
-            desc::DescHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(desc::DescHandler::CLUSTER.id)),
             Async(desc::DescHandler::new(Dataver::new_rand(stack.matter().rand())).adapt()),
         );
 

--- a/examples/esp/src/bin/light_wifi.rs
+++ b/examples/esp/src/bin/light_wifi.rs
@@ -29,7 +29,7 @@ use log::info;
 use rs_matter_embassy::epoch::epoch;
 use rs_matter_embassy::matter::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter_embassy::matter::data_model::objects::{
-    Async, Dataver, EmptyHandler, Endpoint, Node,
+    Async, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter_embassy::matter::data_model::on_off::{self, ClusterHandler as _};
 use rs_matter_embassy::matter::data_model::system_model::desc::{self, ClusterHandler as _};
@@ -105,15 +105,13 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            LIGHT_ENDPOINT_ID,
-            on_off::OnOffHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too
         // Just use the one that `rs-matter` provides out of the box
         .chain(
-            LIGHT_ENDPOINT_ID,
-            desc::DescHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(desc::DescHandler::CLUSTER.id)),
             Async(desc::DescHandler::new(Dataver::new_rand(stack.matter().rand())).adapt()),
         );
 

--- a/examples/esp/src/bin/light_wifi.rs
+++ b/examples/esp/src/bin/light_wifi.rs
@@ -105,7 +105,10 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
+            EpClMatcher::new(
+                Some(LIGHT_ENDPOINT_ID),
+                Some(on_off::OnOffHandler::CLUSTER.id),
+            ),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too

--- a/examples/nrf/src/bin/light_eth.rs
+++ b/examples/nrf/src/bin/light_eth.rs
@@ -212,7 +212,10 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
+            EpClMatcher::new(
+                Some(LIGHT_ENDPOINT_ID),
+                Some(on_off::OnOffHandler::CLUSTER.id),
+            ),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too

--- a/examples/nrf/src/bin/light_eth.rs
+++ b/examples/nrf/src/bin/light_eth.rs
@@ -35,7 +35,7 @@ use rs_matter_embassy::epoch::epoch;
 use rs_matter_embassy::matter::data_model::basic_info::BasicInfoConfig;
 use rs_matter_embassy::matter::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter_embassy::matter::data_model::objects::{
-    Async, Dataver, EmptyHandler, Endpoint, Node,
+    Async, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter_embassy::matter::data_model::on_off::{self, ClusterHandler as _};
 use rs_matter_embassy::matter::data_model::system_model::desc::{self, ClusterHandler as _};
@@ -212,15 +212,13 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            LIGHT_ENDPOINT_ID,
-            on_off::OnOffHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too
         // Just use the one that `rs-matter` provides out of the box
         .chain(
-            LIGHT_ENDPOINT_ID,
-            desc::DescHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(desc::DescHandler::CLUSTER.id)),
             Async(desc::DescHandler::new(Dataver::new_rand(stack.matter().rand())).adapt()),
         );
 

--- a/examples/nrf/src/bin/light_thread.rs
+++ b/examples/nrf/src/bin/light_thread.rs
@@ -194,7 +194,10 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
+            EpClMatcher::new(
+                Some(LIGHT_ENDPOINT_ID),
+                Some(on_off::OnOffHandler::CLUSTER.id),
+            ),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too

--- a/examples/nrf/src/bin/light_thread.rs
+++ b/examples/nrf/src/bin/light_thread.rs
@@ -31,7 +31,7 @@ use rs_matter_embassy::epoch::epoch;
 use rs_matter_embassy::matter::data_model::basic_info::BasicInfoConfig;
 use rs_matter_embassy::matter::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter_embassy::matter::data_model::objects::{
-    Async, Dataver, EmptyHandler, Endpoint, Node,
+    Async, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter_embassy::matter::data_model::on_off::{self, ClusterHandler as _};
 use rs_matter_embassy::matter::data_model::system_model::desc::{self, ClusterHandler as _};
@@ -194,15 +194,13 @@ async fn main(_s: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            LIGHT_ENDPOINT_ID,
-            on_off::OnOffHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too
         // Just use the one that `rs-matter` provides out of the box
         .chain(
-            LIGHT_ENDPOINT_ID,
-            desc::DescHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(desc::DescHandler::CLUSTER.id)),
             Async(desc::DescHandler::new(Dataver::new_rand(stack.matter().rand())).adapt()),
         );
 

--- a/examples/rp/src/bin/light_eth.rs
+++ b/examples/rp/src/bin/light_eth.rs
@@ -31,7 +31,7 @@ use rs_matter_embassy::eth::{EmbassyEthMatterStack, EmbassyEthernet, Preexisting
 use rs_matter_embassy::matter::data_model::basic_info::BasicInfoConfig;
 use rs_matter_embassy::matter::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter_embassy::matter::data_model::objects::{
-    Async, Dataver, EmptyHandler, Endpoint, Node,
+    Async, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter_embassy::matter::data_model::on_off::{self, ClusterHandler as _};
 use rs_matter_embassy::matter::data_model::system_model::desc::{self, ClusterHandler as _};
@@ -146,15 +146,13 @@ async fn main(spawner: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            LIGHT_ENDPOINT_ID,
-            on_off::OnOffHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too
         // Just use the one that `rs-matter` provides out of the box
         .chain(
-            LIGHT_ENDPOINT_ID,
-            desc::DescHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(desc::DescHandler::CLUSTER.id)),
             Async(desc::DescHandler::new(Dataver::new_rand(stack.matter().rand())).adapt()),
         );
 

--- a/examples/rp/src/bin/light_eth.rs
+++ b/examples/rp/src/bin/light_eth.rs
@@ -146,7 +146,10 @@ async fn main(spawner: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
+            EpClMatcher::new(
+                Some(LIGHT_ENDPOINT_ID),
+                Some(on_off::OnOffHandler::CLUSTER.id),
+            ),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too

--- a/examples/rp/src/bin/light_wifi.rs
+++ b/examples/rp/src/bin/light_wifi.rs
@@ -43,7 +43,7 @@ use rs_matter_embassy::enet::{
 use rs_matter_embassy::epoch::epoch;
 use rs_matter_embassy::matter::data_model::device_types::DEV_TYPE_ON_OFF_LIGHT;
 use rs_matter_embassy::matter::data_model::objects::{
-    Async, Dataver, EmptyHandler, Endpoint, Node,
+    Async, Dataver, EmptyHandler, Endpoint, EpClMatcher, Node,
 };
 use rs_matter_embassy::matter::data_model::on_off::{self, ClusterHandler as _};
 use rs_matter_embassy::matter::data_model::system_model::desc::{self, ClusterHandler as _};
@@ -182,15 +182,13 @@ async fn main(spawner: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            LIGHT_ENDPOINT_ID,
-            on_off::OnOffHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too
         // Just use the one that `rs-matter` provides out of the box
         .chain(
-            LIGHT_ENDPOINT_ID,
-            desc::DescHandler::CLUSTER.id,
+            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(desc::DescHandler::CLUSTER.id)),
             Async(desc::DescHandler::new(Dataver::new_rand(stack.matter().rand())).adapt()),
         );
 

--- a/examples/rp/src/bin/light_wifi.rs
+++ b/examples/rp/src/bin/light_wifi.rs
@@ -182,7 +182,10 @@ async fn main(spawner: Spawner) {
     let handler = EmptyHandler
         // Our on-off cluster, on Endpoint 1
         .chain(
-            EpClMatcher::new(Some(LIGHT_ENDPOINT_ID), Some(on_off::OnOffHandler::CLUSTER.id)),
+            EpClMatcher::new(
+                Some(LIGHT_ENDPOINT_ID),
+                Some(on_off::OnOffHandler::CLUSTER.id),
+            ),
             Async(on_off::HandlerAdaptor(&on_off)),
         )
         // Each Endpoint needs a Descriptor cluster too


### PR DESCRIPTION
It seems that the inputs for the `.chain()` method have been modified and the examples no longer build.

This PR fixes this by using the required `EpClMatcher` to input the endpoint and cluster IDs.