### PR TITLE
Make the Matter stack on the esps statically allocated

### DIFF
--- a/examples/esp/src/bin/light_eth.rs
+++ b/examples/esp/src/bin/light_eth.rs
@@ -43,23 +43,34 @@ extern crate alloc;
 
 macro_rules! mk_static {
     ($t:ty) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit();
-        x
-    }};
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write($val);
-        x
+        #[cfg(not(feature = "esp32"))]
+        {
+            static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+            STATIC_CELL.uninit()
+        }
+        #[cfg(feature = "esp32")]
+        alloc::boxed::Box::leak(alloc::boxed::Box::<$t>::new_uninit())
     }};
 }
 
+/// The amount of memory for allocating all `rs-matter-stack` futures created during
+/// the execution of the `run*` methods.
+/// This does NOT include the rest of the Matter stack.
+///
+/// The futures of `rs-matter-stack` created during the execution of the `run*` methods
+/// are allocated in a special way using a small bump allocator which results
+/// in a much lower memory usage by those.
+///
+/// If - for your platform - this size is not enough, increase it until
+/// the program runs without panics during the stack initialization.
 const BUMP_SIZE: usize = 16500;
 
 /// Heap strictly necessary only for Wifi+BLE and for the only Matter dependency which needs (~4KB) alloc - `x509`
+#[cfg(not(feature = "esp32"))]
 const HEAP_SIZE: usize = 100 * 1024;
+/// On the esp32, we allocate the Matter Stack from heap as well, due to the non-contiguous memory regions on that chip
+#[cfg(feature = "esp32")]
+const HEAP_SIZE: usize = 140 * 1024;
 
 const WIFI_SSID: &str = env!("WIFI_SSID");
 const WIFI_PASS: &str = env!("WIFI_PASS");

--- a/examples/esp/src/bin/light_eth2.rs
+++ b/examples/esp/src/bin/light_eth2.rs
@@ -49,23 +49,34 @@ extern crate alloc;
 
 macro_rules! mk_static {
     ($t:ty) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit();
-        x
-    }};
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write($val);
-        x
+        #[cfg(not(feature = "esp32"))]
+        {
+            static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+            STATIC_CELL.uninit()
+        }
+        #[cfg(feature = "esp32")]
+        alloc::boxed::Box::leak(alloc::boxed::Box::<$t>::new_uninit())
     }};
 }
 
+/// The amount of memory for allocating all `rs-matter-stack` futures created during
+/// the execution of the `run*` methods.
+/// This does NOT include the rest of the Matter stack.
+///
+/// The futures of `rs-matter-stack` created during the execution of the `run*` methods
+/// are allocated in a special way using a small bump allocator which results
+/// in a much lower memory usage by those.
+///
+/// If - for your platform - this size is not enough, increase it until
+/// the program runs without panics during the stack initialization.
 const BUMP_SIZE: usize = 18500;
 
 /// Heap strictly necessary only for Wifi+BLE and for the only Matter dependency which needs (~4KB) alloc - `x509`
+#[cfg(not(feature = "esp32"))]
 const HEAP_SIZE: usize = 100 * 1024;
+/// On the esp32, we allocate the Matter Stack from heap as well, due to the non-contiguous memory regions on that chip
+#[cfg(feature = "esp32")]
+const HEAP_SIZE: usize = 140 * 1024;
 
 const THREAD_DATASET: &str = env!("THREAD_DATASET");
 

--- a/examples/esp/src/bin/light_thread.rs
+++ b/examples/esp/src/bin/light_thread.rs
@@ -12,12 +12,11 @@
 
 use core::pin::pin;
 
-use alloc::boxed::Box;
-
 use embassy_executor::Spawner;
 
 use esp_alloc::heap_allocator;
 use esp_backtrace as _;
+use esp_hal::ram;
 use esp_hal::timer::timg::TimerGroup;
 
 use log::info;
@@ -42,14 +41,25 @@ use tinyrlibc as _;
 
 extern crate alloc;
 
+macro_rules! mk_static {
+    ($t:ty) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit();
+        x
+    }};
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write($val);
+        x
+    }};
+}
+
 const BUMP_SIZE: usize = 25000;
 
-#[cfg(feature = "esp32")]
-const HEAP_SIZE: usize = 40 * 1024; // 40KB for ESP32, which has a disjoint heap
-#[cfg(any(feature = "esp32c3", feature = "esp32h2"))]
-const HEAP_SIZE: usize = 160 * 1024;
-#[cfg(not(any(feature = "esp32", feature = "esp32c3", feature = "esp32h2")))]
-const HEAP_SIZE: usize = 186 * 1024;
+/// Heap strictly necessary only for Wifi+BLE and for the only Matter dependency which needs (~4KB) alloc - `x509`
+const HEAP_SIZE: usize = 100 * 1024;
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
@@ -59,12 +69,8 @@ async fn main(_s: Spawner) {
 
     info!("Starting...");
 
-    // Heap strictly necessary only for Wifi+BLE and for the only Matter dependency which needs (~4KB) alloc - `x509`
-    // However since `esp32` specifically has a disjoint heap which causes bss size troubles, it is easier
-    // to allocate the statics once from heap as well
-    heap_allocator!(size: HEAP_SIZE);
-    #[cfg(feature = "esp32")]
-    heap_allocator!(#[link_section = ".dram2_uninit"] size: 96 * 1024);
+    heap_allocator!(size: HEAP_SIZE - RECLAIMED_RAM);
+    heap_allocator!(#[ram(reclaimed)] size: RECLAIMED_RAM);
 
     // == Step 1: ==
     // Necessary `esp-hal` initialization boilerplate
@@ -99,8 +105,8 @@ async fn main(_s: Spawner) {
     // Allocate the Matter stack.
     // For MCUs, it is best to allocate it statically, so as to avoid program stack blowups (its memory footprint is ~ 35 to 50KB).
     // It is also (currently) a mandatory requirement when the wireless stack variation is used.
-    let stack =
-        &*Box::leak(Box::new_uninit()).init_with(EmbassyThreadMatterStack::<BUMP_SIZE, ()>::init(
+    let stack = mk_static!(EmbassyThreadMatterStack::<BUMP_SIZE, ()>).init_with(
+        EmbassyThreadMatterStack::init(
             &TEST_BASIC_INFO,
             BasicCommData {
                 password: TEST_DEV_COMM.password,
@@ -109,7 +115,8 @@ async fn main(_s: Spawner) {
             &TEST_DEV_ATT,
             epoch,
             esp_rand,
-        ));
+        ),
+    );
 
     // == Step 4: ==
     // Our "light" on-off cluster.
@@ -193,3 +200,16 @@ const NODE: Node = Node {
         },
     ],
 };
+
+#[cfg(feature = "esp32")]
+const RECLAIMED_RAM: usize = 98767;
+#[cfg(feature = "esp32c2")]
+const RECLAIMED_RAM: usize = 66416;
+#[cfg(feature = "esp32c3")]
+const RECLAIMED_RAM: usize = 66320;
+#[cfg(feature = "esp32c6")]
+const RECLAIMED_RAM: usize = 65536;
+#[cfg(feature = "esp32h2")]
+const RECLAIMED_RAM: usize = 69392;
+#[cfg(feature = "esp32s3")]
+const RECLAIMED_RAM: usize = 73744;

--- a/examples/esp/src/bin/light_thread_coex.rs
+++ b/examples/esp/src/bin/light_thread_coex.rs
@@ -44,23 +44,34 @@ extern crate alloc;
 
 macro_rules! mk_static {
     ($t:ty) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit();
-        x
-    }};
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write($val);
-        x
+        #[cfg(not(feature = "esp32"))]
+        {
+            static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+            STATIC_CELL.uninit()
+        }
+        #[cfg(feature = "esp32")]
+        alloc::boxed::Box::leak(alloc::boxed::Box::<$t>::new_uninit())
     }};
 }
 
+/// The amount of memory for allocating all `rs-matter-stack` futures created during
+/// the execution of the `run*` methods.
+/// This does NOT include the rest of the Matter stack.
+///
+/// The futures of `rs-matter-stack` created during the execution of the `run*` methods
+/// are allocated in a special way using a small bump allocator which results
+/// in a much lower memory usage by those.
+///
+/// If - for your platform - this size is not enough, increase it until
+/// the program runs without panics during the stack initialization.
 const BUMP_SIZE: usize = 18500;
 
 /// Heap strictly necessary only for Wifi+BLE and for the only Matter dependency which needs (~4KB) alloc - `x509`
+#[cfg(not(feature = "esp32"))]
 const HEAP_SIZE: usize = 100 * 1024;
+/// On the esp32, we allocate the Matter Stack from heap as well, due to the non-contiguous memory regions on that chip
+#[cfg(feature = "esp32")]
+const HEAP_SIZE: usize = 140 * 1024;
 
 esp_bootloader_esp_idf::esp_app_desc!();
 

--- a/examples/esp/src/bin/light_wifi.rs
+++ b/examples/esp/src/bin/light_wifi.rs
@@ -16,12 +16,11 @@
 
 use core::pin::pin;
 
-use alloc::boxed::Box;
-
 use embassy_executor::Spawner;
 
 use esp_alloc::heap_allocator;
 use esp_backtrace as _;
+use esp_hal::ram;
 use esp_hal::timer::timg::TimerGroup;
 
 use log::info;
@@ -42,15 +41,25 @@ use rs_matter_embassy::wireless::{EmbassyWifi, EmbassyWifiMatterStack};
 
 extern crate alloc;
 
-const BUMP_SIZE: usize = 30000;
-//const BUMP_SIZE: usize = 16500;
+macro_rules! mk_static {
+    ($t:ty) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit();
+        x
+    }};
+    ($t:ty,$val:expr) => {{
+        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+        #[deny(unused_attributes)]
+        let x = STATIC_CELL.uninit().write($val);
+        x
+    }};
+}
 
-#[cfg(feature = "esp32")]
-const HEAP_SIZE: usize = 40 * 1024; // 40KB for ESP32, which has a disjoint heap
-#[cfg(any(feature = "esp32c3", feature = "esp32h2"))]
-const HEAP_SIZE: usize = 160 * 1024;
-#[cfg(not(any(feature = "esp32", feature = "esp32c3", feature = "esp32h2")))]
-const HEAP_SIZE: usize = 186 * 1024;
+const BUMP_SIZE: usize = 16500;
+
+/// Heap strictly necessary only for Wifi+BLE and for the only Matter dependency which needs (~4KB) alloc - `x509`
+const HEAP_SIZE: usize = 100 * 1024;
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
@@ -60,12 +69,8 @@ async fn main(_s: Spawner) {
 
     info!("Starting...");
 
-    // Heap strictly necessary only for Wifi+BLE and for the only Matter dependency which needs (~4KB) alloc - `x509`
-    // However since `esp32` specifically has a disjoint heap which causes bss size troubles, it is easier
-    // to allocate the statics once from heap as well
-    heap_allocator!(size: HEAP_SIZE);
-    #[cfg(feature = "esp32")]
-    heap_allocator!(#[link_section = ".dram2_uninit"] size: 96 * 1024);
+    heap_allocator!(size: HEAP_SIZE - RECLAIMED_RAM);
+    heap_allocator!(#[ram(reclaimed)] size: RECLAIMED_RAM);
 
     // == Step 1: ==
     // Necessary `esp-hal` and `esp-wifi` initialization boilerplate
@@ -90,14 +95,9 @@ async fn main(_s: Spawner) {
     // Allocate the Matter stack.
     // For MCUs, it is best to allocate it statically, so as to avoid program stack blowups (its memory footprint is ~ 35 to 50KB).
     // It is also (currently) a mandatory requirement when the wireless stack variation is used.
-    let stack =
-        &*Box::leak(Box::new_uninit()).init_with(EmbassyWifiMatterStack::<BUMP_SIZE, ()>::init(
-            &TEST_DEV_DET,
-            TEST_DEV_COMM,
-            &TEST_DEV_ATT,
-            epoch,
-            esp_rand,
-        ));
+    let stack = mk_static!(EmbassyWifiMatterStack::<BUMP_SIZE, ()>).init_with(
+        EmbassyWifiMatterStack::init(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, epoch, esp_rand),
+    );
 
     // == Step 3: ==
     // Our "light" on-off cluster.
@@ -172,3 +172,16 @@ const NODE: Node = Node {
         },
     ],
 };
+
+#[cfg(feature = "esp32")]
+const RECLAIMED_RAM: usize = 98767;
+#[cfg(feature = "esp32c2")]
+const RECLAIMED_RAM: usize = 66416;
+#[cfg(feature = "esp32c3")]
+const RECLAIMED_RAM: usize = 66320;
+#[cfg(feature = "esp32c6")]
+const RECLAIMED_RAM: usize = 65536;
+#[cfg(feature = "esp32h2")]
+const RECLAIMED_RAM: usize = 69392;
+#[cfg(feature = "esp32s3")]
+const RECLAIMED_RAM: usize = 73744;

--- a/examples/esp/src/bin/light_wifi.rs
+++ b/examples/esp/src/bin/light_wifi.rs
@@ -42,7 +42,8 @@ use rs_matter_embassy::wireless::{EmbassyWifi, EmbassyWifiMatterStack};
 
 extern crate alloc;
 
-const BUMP_SIZE: usize = 16500;
+const BUMP_SIZE: usize = 30000;
+//const BUMP_SIZE: usize = 16500;
 
 #[cfg(feature = "esp32")]
 const HEAP_SIZE: usize = 40 * 1024; // 40KB for ESP32, which has a disjoint heap

--- a/examples/esp/src/bin/light_wifi.rs
+++ b/examples/esp/src/bin/light_wifi.rs
@@ -43,23 +43,34 @@ extern crate alloc;
 
 macro_rules! mk_static {
     ($t:ty) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit();
-        x
-    }};
-    ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write($val);
-        x
+        #[cfg(not(feature = "esp32"))]
+        {
+            static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+            STATIC_CELL.uninit()
+        }
+        #[cfg(feature = "esp32")]
+        alloc::boxed::Box::leak(alloc::boxed::Box::<$t>::new_uninit())
     }};
 }
 
+/// The amount of memory for allocating all `rs-matter-stack` futures created during
+/// the execution of the `run*` methods.
+/// This does NOT include the rest of the Matter stack.
+///
+/// The futures of `rs-matter-stack` created during the execution of the `run*` methods
+/// are allocated in a special way using a small bump allocator which results
+/// in a much lower memory usage by those.
+///
+/// If - for your platform - this size is not enough, increase it until
+/// the program runs without panics during the stack initialization.
 const BUMP_SIZE: usize = 16500;
 
 /// Heap strictly necessary only for Wifi+BLE and for the only Matter dependency which needs (~4KB) alloc - `x509`
+#[cfg(not(feature = "esp32"))]
 const HEAP_SIZE: usize = 100 * 1024;
+/// On the esp32, we allocate the Matter Stack from heap as well, due to the non-contiguous memory regions on that chip
+#[cfg(feature = "esp32")]
+const HEAP_SIZE: usize = 140 * 1024;
 
 esp_bootloader_esp_idf::esp_app_desc!();
 

--- a/examples/nrf/src/bin/light_eth.rs
+++ b/examples/nrf/src/bin/light_eth.rs
@@ -56,15 +56,10 @@ use tinyrlibc as _;
 macro_rules! mk_static {
     ($t:ty) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit();
-        x
+        STATIC_CELL.uninit()
     }};
     ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write($val);
-        x
+        mk_static!($t).write($val)
     }};
 }
 
@@ -79,6 +74,16 @@ unsafe fn EGU1_SWI1() {
 
 static RADIO_EXECUTOR: InterruptExecutor = InterruptExecutor::new();
 
+/// The amount of memory for allocating all `rs-matter-stack` futures created during
+/// the execution of the `run*` methods.
+/// This does NOT include the rest of the Matter stack.
+///
+/// The futures of `rs-matter-stack` created during the execution of the `run*` methods
+/// are allocated in a special way using a small bump allocator which results
+/// in a much lower memory usage by those.
+///
+/// If - for your platform - this size is not enough, increase it until
+/// the program runs without panics during the stack initialization.
 const BUMP_SIZE: usize = 15500;
 
 #[global_allocator]

--- a/examples/nrf/src/bin/light_thread.rs
+++ b/examples/nrf/src/bin/light_thread.rs
@@ -50,15 +50,10 @@ use tinyrlibc as _;
 macro_rules! mk_static {
     ($t:ty) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit();
-        x
+        STATIC_CELL.uninit()
     }};
     ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write($val);
-        x
+        mk_static!($t).write($val)
     }};
 }
 
@@ -78,6 +73,16 @@ unsafe fn EGU1_SWI1() {
 
 static RADIO_EXECUTOR: InterruptExecutor = InterruptExecutor::new();
 
+/// The amount of memory for allocating all `rs-matter-stack` futures created during
+/// the execution of the `run*` methods.
+/// This does NOT include the rest of the Matter stack.
+///
+/// The futures of `rs-matter-stack` created during the execution of the `run*` methods
+/// are allocated in a special way using a small bump allocator which results
+/// in a much lower memory usage by those.
+///
+/// If - for your platform - this size is not enough, increase it until
+/// the program runs without panics during the stack initialization.
 const BUMP_SIZE: usize = 20500;
 
 #[global_allocator]

--- a/examples/rp/src/bin/light_eth.rs
+++ b/examples/rp/src/bin/light_eth.rs
@@ -49,18 +49,23 @@ use panic_rtt_target as _;
 macro_rules! mk_static {
     ($t:ty) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit();
-        x
+        STATIC_CELL.uninit()
     }};
     ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write($val);
-        x
+        mk_static!($t).write($val)
     }};
 }
 
+/// The amount of memory for allocating all `rs-matter-stack` futures created during
+/// the execution of the `run*` methods.
+/// This does NOT include the rest of the Matter stack.
+///
+/// The futures of `rs-matter-stack` created during the execution of the `run*` methods
+/// are allocated in a special way using a small bump allocator which results
+/// in a much lower memory usage by those.
+///
+/// If - for your platform - this size is not enough, increase it until
+/// the program runs without panics during the stack initialization.
 const BUMP_SIZE: usize = 16500;
 
 #[global_allocator]

--- a/examples/rp/src/bin/light_wifi.rs
+++ b/examples/rp/src/bin/light_wifi.rs
@@ -47,15 +47,10 @@ use rs_matter_embassy::wireless::{EmbassyWifi, EmbassyWifiMatterStack};
 macro_rules! mk_static {
     ($t:ty) => {{
         static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit();
-        x
+        STATIC_CELL.uninit()
     }};
     ($t:ty,$val:expr) => {{
-        static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
-        #[deny(unused_attributes)]
-        let x = STATIC_CELL.uninit().write($val);
-        x
+        mk_static!($t).write($val)
     }};
 }
 
@@ -63,6 +58,16 @@ bind_interrupts!(struct Irqs {
     PIO0_IRQ_0 => InterruptHandler<PIO0>;
 });
 
+/// The amount of memory for allocating all `rs-matter-stack` futures created during
+/// the execution of the `run*` methods.
+/// This does NOT include the rest of the Matter stack.
+///
+/// The futures of `rs-matter-stack` created during the execution of the `run*` methods
+/// are allocated in a special way using a small bump allocator which results
+/// in a much lower memory usage by those.
+///
+/// If - for your platform - this size is not enough, increase it until
+/// the program runs without panics during the stack initialization.
 const BUMP_SIZE: usize = 16500;
 
 #[global_allocator]

--- a/rs-matter-embassy/README.md
+++ b/rs-matter-embassy/README.md
@@ -34,12 +34,11 @@ Everything necessary to run [`rs-matter`](https://github.com/project-chip/rs-mat
 
 use core::pin::pin;
 
-use alloc::boxed::Box;
-
 use embassy_executor::Spawner;
 
 use esp_alloc::heap_allocator;
 use esp_backtrace as _;
+use esp_hal::ram;
 use esp_hal::timer::timg::TimerGroup;
 
 use log::info;
@@ -60,14 +59,36 @@ use rs_matter_embassy::wireless::{EmbassyWifi, EmbassyWifiMatterStack};
 
 extern crate alloc;
 
+macro_rules! mk_static {
+    ($t:ty) => {{
+        #[cfg(not(feature = "esp32"))]
+        {
+            static STATIC_CELL: static_cell::StaticCell<$t> = static_cell::StaticCell::new();
+            STATIC_CELL.uninit()
+        }
+        #[cfg(feature = "esp32")]
+        alloc::boxed::Box::leak(alloc::boxed::Box::<$t>::new_uninit())
+    }};
+}
+
+/// The amount of memory for allocating all `rs-matter-stack` futures created during
+/// the execution of the `run*` methods.
+/// This does NOT include the rest of the Matter stack.
+///
+/// The futures of `rs-matter-stack` created during the execution of the `run*` methods
+/// are allocated in a special way using a small bump allocator which results
+/// in a much lower memory usage by those.
+///
+/// If - for your platform - this size is not enough, increase it until
+/// the program runs without panics during the stack initialization.
 const BUMP_SIZE: usize = 16500;
 
+/// Heap strictly necessary only for Wifi+BLE and for the only Matter dependency which needs (~4KB) alloc - `x509`
+#[cfg(not(feature = "esp32"))]
+const HEAP_SIZE: usize = 100 * 1024;
+/// On the esp32, we allocate the Matter Stack from heap as well, due to the non-contiguous memory regions on that chip
 #[cfg(feature = "esp32")]
-const HEAP_SIZE: usize = 40 * 1024; // 40KB for ESP32, which has a disjoint heap
-#[cfg(any(feature = "esp32c3", feature = "esp32h2"))]
-const HEAP_SIZE: usize = 160 * 1024;
-#[cfg(not(any(feature = "esp32", feature = "esp32c3", feature = "esp32h2")))]
-const HEAP_SIZE: usize = 186 * 1024;
+const HEAP_SIZE: usize = 140 * 1024;
 
 esp_bootloader_esp_idf::esp_app_desc!();
 
@@ -77,12 +98,8 @@ async fn main(_s: Spawner) {
 
     info!("Starting...");
 
-    // Heap strictly necessary only for Wifi+BLE and for the only Matter dependency which needs (~4KB) alloc - `x509`
-    // However since `esp32` specifically has a disjoint heap which causes bss size troubles, it is easier
-    // to allocate the statics once from heap as well
-    heap_allocator!(size: HEAP_SIZE);
-    #[cfg(feature = "esp32")]
-    heap_allocator!(#[link_section = ".dram2_uninit"] size: 96 * 1024);
+    heap_allocator!(size: HEAP_SIZE - RECLAIMED_RAM);
+    heap_allocator!(#[ram(reclaimed)] size: RECLAIMED_RAM);
 
     // == Step 1: ==
     // Necessary `esp-hal` and `esp-wifi` initialization boilerplate
@@ -107,14 +124,9 @@ async fn main(_s: Spawner) {
     // Allocate the Matter stack.
     // For MCUs, it is best to allocate it statically, so as to avoid program stack blowups (its memory footprint is ~ 35 to 50KB).
     // It is also (currently) a mandatory requirement when the wireless stack variation is used.
-    let stack =
-        &*Box::leak(Box::new_uninit()).init_with(EmbassyWifiMatterStack::<BUMP_SIZE, ()>::init(
-            &TEST_DEV_DET,
-            TEST_DEV_COMM,
-            &TEST_DEV_ATT,
-            epoch,
-            esp_rand,
-        ));
+    let stack = mk_static!(EmbassyWifiMatterStack::<BUMP_SIZE, ()>).init_with(
+        EmbassyWifiMatterStack::init(&TEST_DEV_DET, TEST_DEV_COMM, &TEST_DEV_ATT, epoch, esp_rand),
+    );
 
     // == Step 3: ==
     // Our "light" on-off cluster.
@@ -189,6 +201,19 @@ const NODE: Node = Node {
         },
     ],
 };
+
+#[cfg(feature = "esp32")]
+const RECLAIMED_RAM: usize = 98767;
+#[cfg(feature = "esp32c2")]
+const RECLAIMED_RAM: usize = 66416;
+#[cfg(feature = "esp32c3")]
+const RECLAIMED_RAM: usize = 66320;
+#[cfg(feature = "esp32c6")]
+const RECLAIMED_RAM: usize = 65536;
+#[cfg(feature = "esp32h2")]
+const RECLAIMED_RAM: usize = 69392;
+#[cfg(feature = "esp32s3")]
+const RECLAIMED_RAM: usize = 73744;
 ```
 
 ## Future


### PR DESCRIPTION
... or else it is not part of DRAM or at least not a "visible" part of DRAM, as it goes into the 160KB-or-so DRAM chunk dedicated for heap llocations together with the Wifi blob / BLE blob and `esp-rtos`. Thus making it less transparent what is the **actual** memory consumption of the Matter stack itself.

For the "esp32" specifically, the code branches and _still_ allocates the stack from heap, because - due to the fragmented memory layout of the esp32 it is just not possible to do it in a different way.

One TODO which is not adressed yet: coming up with the **minimal** amount of heap that is enough to make the whole stack operational (i.e. Wifi & BLE to work without errors). Currently, we always dedicate 100KB heap on all chips but the "esp32", but whether that's too much is yet to be checked.
