### PR TITLE
Increase BUMP_SIZE for nrf example

### DIFF
--- a/examples/nrf/src/bin/light_thread.rs
+++ b/examples/nrf/src/bin/light_thread.rs
@@ -86,7 +86,7 @@ static RADIO_EXECUTOR: InterruptExecutor = InterruptExecutor::new();
 ///
 /// If - for your platform - this size is not enough, increase it until
 /// the program runs without panics during the stack initialization.
-const BUMP_SIZE: usize = 20500;
+const BUMP_SIZE: usize = 21320 + 4 + 2976;
 
 #[global_allocator]
 static HEAP: LlffHeap = LlffHeap::empty();


### PR DESCRIPTION
I was trying the `light_thread.rs` example on a nrf52840 board and hit an OOM with the default BUMP_SIZE value. Increasing it using the values printed in the logs plus some for alignment seems to work.


<details><summary>Logs from OOM build</summary>

```
0.000 [INFO ] Starting... (light_thread src/bin/light_thread.rs:111)
0.002 [INFO ] Device is not commissioned yet, opening commissioning window... (rs_matter_stack d446a23/src/wireless.rs:194)
0.002 [INFO ] PASE Basic Commissioning Window opened (rs_matter src/sc/pase.rs:283)
0.004 [INFO ] SetupQRCode: [MT:-24J0-C71422064IJ3P0WISA0DK5N1K8SQ1RYCU1O0] (rs_matter rs-matter/src/lib.rs:409)
0.004 [INFO ] PairingCode: [1005-4912-339] (rs_matter rs-matter/src/lib.rs:431)
0.125 [INFO ] █████████████████████████████████████ (rs_matter rs-matter/src/lib.rs:452)
0.126 [INFO ] █████████████████████████████████████ (rs_matter rs-matter/src/lib.rs:452)
0.127 [INFO ] ████ ▄▄▄▄▄ █  █▀█ ▄▄▀▀ █▀█ ▄▄▄▄▄ ████ (rs_matter rs-matter/src/lib.rs:452)
0.128 [INFO ] ████ █   █ █▀▀ ▄██▀▀▄█▀  █ █   █ ████ (rs_matter rs-matter/src/lib.rs:452)
0.130 [INFO ] ████ █▄▄▄█ ██▄ ▄▄▀▄▀  ▄ ██ █▄▄▄█ ████ (rs_matter rs-matter/src/lib.rs:452)
0.131 [INFO ] ████▄▄▄▄▄▄▄█ █ ▀▄█▄▀ ▀ █▄█▄▄▄▄▄▄▄████ (rs_matter rs-matter/src/lib.rs:452)
0.132 [INFO ] ████ ▀▄ █ ▄▄▀█▄█  ▀ █▀▀  ▀ █▀ █▄▄████ (rs_matter rs-matter/src/lib.rs:452)
0.133 [INFO ] ████▀▀ █ █▄  █▄ █▄██ ▄▀▀█▄███ ▀██████ (rs_matter rs-matter/src/lib.rs:452)
0.134 [INFO ] ████▄▄▀  ▀▄▄▄█ █▀█ ▄▀ ▄▄█▀▀ ▄▄█▄▄████ (rs_matter rs-matter/src/lib.rs:452)
0.136 [INFO ] ████▀█  ▄▀▄ ▀█   ▄▀▄ ▀ ▄█▀▀ █▄ ▄▀████ (rs_matter rs-matter/src/lib.rs:452)
0.137 [INFO ] ██████▄██▀▄▄▄█▄ ▄█ ▄▀█▄▄███▄▄▄▀ ▄████ (rs_matter rs-matter/src/lib.rs:452)
0.138 [INFO ] ████▄█▀  █▄██▀█ ▄  ▄█ ▀▀█▄▄▀     ████ (rs_matter rs-matter/src/lib.rs:452)
0.139 [INFO ] █████▄▄███▄▄▀▄ ▀ ▄▄▀▄▀▀▄ ▄▄▄ ▄█▄▀████ (rs_matter rs-matter/src/lib.rs:452)
0.140 [INFO ] ████ ▄▄▄▄▄ █ ███▄▀ █▀███ █▄█  ▄█▄████ (rs_matter rs-matter/src/lib.rs:452)
0.142 [INFO ] ████ █   █ █▀█▄▀███ █▄ ▀▄▄▄▄▄▀ ▀█████ (rs_matter rs-matter/src/lib.rs:452)
0.143 [INFO ] ████ █▄▄▄█ █▄██▀▄▄▀ ▄▄▀▄█▀▄▄▄█ ▀ ████ (rs_matter rs-matter/src/lib.rs:452)
0.144 [INFO ] ████▄▄▄▄▄▄▄█▄▄███▄▄▄█▄██▄▄█▄██▄██████ (rs_matter rs-matter/src/lib.rs:452)
0.145 [INFO ] █████████████████████████████████████ (rs_matter rs-matter/src/lib.rs:452)
0.147 [INFO ] █████████████████████████████████████ (rs_matter rs-matter/src/lib.rs:452)
0.248 [INFO ] Matter Stack memory: 74440b (rs_matter_stack src/wireless/thread.rs:152)
0.248 [INFO ] BUMP[/home/alex/.cargo/git/checkouts/rs-matter-stack-6d320ce37ecc289f/d446a23/src/wireless/thread.rs:162]: 21320b (U:0b/F:20500b) (rs_matter_stack d446a23/src/bump.rs:113)
0.249 [ERROR] panicked at 'Out of bump memory' (rs_matter_stack d446a23/src/bump.rs:213)
```

</details>


<details><summary>Logs from build with increased BUMP_SIZE</summary>

```
0.000 [INFO ] Starting... (light_thread src/bin/light_thread.rs:111)
0.002 [INFO ] Device is not commissioned yet, opening commissioning window... (rs_matter_stack d446a23/src/wireless.rs:194)
0.002 [INFO ] PASE Basic Commissioning Window opened (rs_matter src/sc/pase.rs:283)
0.004 [INFO ] SetupQRCode: [MT:-24J0KQS027-.54IJ3P0WISA0DK5N1K8SQ1RYCU1O0] (rs_matter rs-matter/src/lib.rs:409)
0.005 [INFO ] PairingCode: [0005-4912-336] (rs_matter rs-matter/src/lib.rs:431)
0.128 [INFO ] █████████████████████████████████████ (rs_matter rs-matter/src/lib.rs:452)
0.129 [INFO ] █████████████████████████████████████ (rs_matter rs-matter/src/lib.rs:452)
0.131 [INFO ] ████ ▄▄▄▄▄ ██▄ ▀█   ▀█▄███ ▄▄▄▄▄ ████ (rs_matter rs-matter/src/lib.rs:452)
0.132 [INFO ] ████ █   █ █  ▀▀█▄▀ ██ ▀ █ █   █ ████ (rs_matter rs-matter/src/lib.rs:452)
0.133 [INFO ] ████ █▄▄▄█ █ █▄▀███▄▄▀▀▄▄█ █▄▄▄█ ████ (rs_matter rs-matter/src/lib.rs:452)
0.134 [INFO ] ████▄▄▄▄▄▄▄█ █▄█ █ █ █▄█ █▄▄▄▄▄▄▄████ (rs_matter rs-matter/src/lib.rs:452)
0.135 [INFO ] ████▄▀▄▄ ▄▄██▄▄▀ ▀▀▀▄▀ ▀ █▄   ▄██████ (rs_matter rs-matter/src/lib.rs:452)
0.136 [INFO ] ████▀▀  ▀█▄█▄ █▄  ▄ ▄█▄█▄▀▀▀█▄  ▀████ (rs_matter rs-matter/src/lib.rs:452)
0.138 [INFO ] ██████▀█▀ ▄ ▄▄▄█▀█▄ ▀▄ ▄▀█▀█▄▄▀ ▄████ (rs_matter rs-matter/src/lib.rs:452)
0.139 [INFO ] █████▀▀ ▄█▄█▄█▀ ██▀█▀▀▀██   ██ █ ████ (rs_matter rs-matter/src/lib.rs:452)
0.140 [INFO ] ████ ▀▀ ▀█▄▀▄ ▀▄▀▀▀▀█▄▀ ▄ ▀██▄ █ ████ (rs_matter rs-matter/src/lib.rs:452)
0.141 [INFO ] ████ █▀▀▀█▄ ▄ ▀▀▀ ▄ █▄█▀▀ ▄ ▀▄ ▄ ████ (rs_matter rs-matter/src/lib.rs:452)
0.142 [INFO ] ████▄█▄▄▄█▄█ ██▀██▄ █▀ █ ▄▄▄  ▀█ ████ (rs_matter rs-matter/src/lib.rs:452)
0.144 [INFO ] ████ ▄▄▄▄▄ █▀▀██▀█▀ █▄ ▀ █▄█ █   ████ (rs_matter rs-matter/src/lib.rs:452)
0.145 [INFO ] ████ █   █ █  ▄▀▀▀▀▄█ ▄▀  ▄▄  ▀██████ (rs_matter rs-matter/src/lib.rs:452)
0.146 [INFO ] ████ █▄▄▄█ █▄▀  ▀█▄▀█▄ ██ █▀▀▄▀ ▀████ (rs_matter rs-matter/src/lib.rs:452)
0.147 [INFO ] ████▄▄▄▄▄▄▄█▄█▄▄██████▄█████▄██▄█████ (rs_matter rs-matter/src/lib.rs:452)
0.148 [INFO ] █████████████████████████████████████ (rs_matter rs-matter/src/lib.rs:452)
0.150 [INFO ] █████████████████████████████████████ (rs_matter rs-matter/src/lib.rs:452)
0.249 [INFO ] Matter Stack memory: 78240b (rs_matter_stack src/wireless/thread.rs:152)
0.249 [INFO ] BUMP[/home/alex/.cargo/git/checkouts/rs-matter-stack-6d320ce37ecc289f/d446a23/src/wireless/thread.rs:162]: 21320b (U:0b/F:24300b) (rs_matter_stack d446a23/src/bump.rs:113)
0.250 [INFO ] BLE driver started (rs_matter_stack d446a23/src/wireless.rs:292)
0.250 [INFO ] Running in non-concurrent commissioning mode (BLE only) (rs_matter_stack d446a23/src/wireless.rs:294)
0.250 [INFO ] BUMP[/home/alex/.cargo/git/checkouts/rs-matter-stack-6d320ce37ecc289f/d446a23/src/wireless.rs:301]: 2976b (U:21320b/F:2980b) (rs_matter_stack d446a23/src/bump.rs:113)
0.251 [INFO ] Starting advertising and GATT service (rs_matter_embassy rs-matter-embassy/src/ble.rs:168)
0.251 [INFO ] Random GATT address = [210, 102, 224, 230, 235, 164] (rs_matter_embassy rs-matter-embassy/src/ble.rs:195)
0.251 [INFO ] [host] using packet pool with MTU 251 capacity 16 (trouble_host trouble-host-0.6.0/src/host.rs:1127)
0.252 [INFO ] [host] filter accept list size: 8 (trouble_host trouble-host-0.6.0/src/host.rs:1134)
0.252 [INFO ] [host] setting txq to 3, fragmenting at 251 (trouble_host trouble-host-0.6.0/src/host.rs:1137)
0.252 [INFO ] [host] configuring host buffers (1 packets of size 255) (trouble_host trouble-host-0.6.0/src/host.rs:1147)
0.252 [INFO ] [host] initialized (trouble_host trouble-host-0.6.0/src/host.rs:1169)
0.252 [INFO ] GATT: Advertising (rs_matter_embassy rs-matter-embassy/src/ble.rs:300)
0.252 [INFO ] Running Matter transport (rs_matter rs-matter/src/transport.rs:383)
0.252 [INFO ] Responder: Creating 4 handlers (rs_matter rs-matter/src/respond.rs:156)
0.253 [INFO ] Busy Responder: Creating 2 handlers (rs_matter rs-matter/src/respond.rs:156)
5.253 [INFO ] Emulation: out of band toggle request (rs_matter dm/clusters/on_off.rs:1131)
10.253 [INFO ] Emulation: out of band toggle request (rs_matter dm/clusters/on_off.rs:1131)
15.253 [INFO ] Emulation: out of band toggle request (rs_matter dm/clusters/on_off.rs:1131)
```
</details> 