### PR TITLE
fix a potential issue that may block the WifiController indefinitely

### DIFF
--- a/rs-matter-embassy/src/wifi/esp.rs
+++ b/rs-matter-embassy/src/wifi/esp.rs
@@ -102,6 +102,20 @@ impl NetCtl for EspWifiController<'_> {
 
         info!("Wifi connect request for SSID {}", ssid);
 
+        // If already connected, disconnect first to ensure a clean state.
+        // Calling connect_async() while already connected can hang forever
+        // because the ESP WiFi driver may not generate any StationConnected
+        // or StationDisconnected events, leaving the event subscriber loop
+        // waiting indefinitely.
+        if ctl.is_connected() {
+            info!("Wifi already connected, disconnecting first");
+            let _ = ctl.disconnect_async().await;
+
+            self.1.lock(|connected| {
+                connected.set(false);
+            });
+        }
+
         ctl.set_config(&Config::Station(
             StationConfig::default()
                 .with_ssid(ssid)
@@ -110,12 +124,15 @@ impl NetCtl for EspWifiController<'_> {
         .map_err(to_ctl_err)?;
         info!("Wifi configuration updated");
 
-        ctl.connect_async().await.map_err(to_ctl_err)?;
+        let result = ctl.connect_async().await;
 
         self.1.lock(|connected| {
-            info!("Wifi state updated: {} -> {}", connected.get(), true);
-            connected.set(true);
+            let new_state = result.is_ok();
+            info!("Wifi state updated: {} -> {}", connected.get(), new_state);
+            connected.set(new_state);
         });
+
+        result.map_err(to_ctl_err)?;
 
         info!("Wifi connected");
 


### PR DESCRIPTION
# Changes to rs-matter-embassy

## Context

This is a fork of the  `inband-persistence` branch from
`https://github.com/sysgrok/rs-matter-embassy` (commit `3e6a827`), with a
fix applied to resolve a Matter commissioning failure on ESP32-C6 devices.

Should contribute to fix https://github.com/project-chip/rs-matter/issues/409 (at least when used with rs-matter-embassy)

## Problem

During Matter commissioning, the commissioner sends a sequence of commands
over BLE, culminating in a `ConnectNetwork` command that instructs the
device to join a WiFi network. By the time `ConnectNetwork` arrives, the
device is **already connected** to the target WiFi network because the
`WirelessMgr` background task auto-connects as soon as credentials are
stored (during the earlier `AddOrUpdateWiFiNetwork` step).

When `EspWifiController::connect()` is called for the `ConnectNetwork`
command, it calls `connect_async()` on the ESP WiFi controller while the
station is already associated to the same AP. The ESP WiFi firmware's
`esp_wifi_connect_internal()` does not generate a `StationConnected` or
`StationDisconnected` event in this case, so `connect_async()` blocks
forever waiting for an event that never arrives.

This has several cascading effects:

1. **The `IfMutex<WifiController>` is held indefinitely**, blocking the
   `WirelessMgr` and any other code that needs the WiFi controller.
2. **The `ConnectNetworkResponse` is never sent** back to the commissioner
   over BLE, because the handler is stuck awaiting `connect_async()`.
3. **The WiFi RX queue fills up** (`RX QUEUE FULL` log spam) because the
   call to `connect_impl()` sets the station state to `Connecting`, which
   causes `link_state()` to return `Down` and `tx_token()` to return
   `None`. This prevents the embassy-net runner from draining received WiFi
   frames, even though the radio hardware keeps receiving them.
4. **The commissioner eventually times out** and drops the BLE connection,
   causing the pairing to fail.

## Changes

### `rs-matter-embassy/src/wifi/esp.rs` — disconnect before reconnect, fix connected flag

In `EspWifiController::connect()`:

- **Disconnect before reconnect**: Before calling `connect_async()`, the
  code now checks `ctl.is_connected()`. If the WiFi is already connected,
  it calls `ctl.disconnect_async().await` first and sets the cached
  `connected` flag to `false`. This ensures that the subsequent
  `connect_async()` starts from a clean disconnected state and will
  reliably receive a `StationConnected` event when the connection
  succeeds.

- **Fix connected flag on failure**: Previously, if `connect_async()`
  returned an error, the early `?` return meant the `connected` flag was
  never updated — it stayed `true` from the previous successful
  connection. The code now captures the result of `connect_async()`,
  updates the `connected` flag based on `result.is_ok()`, and only then
  propagates the error. This keeps the cached connection state accurate
  regardless of whether the connect attempt succeeds or fails.

## Diff summary

```
 rs-matter-embassy/src/wifi/esp.rs | ~20 lines changed
```
