### PR TITLE
Build the BLE static random address little-endian

### DIFF
--- a/rs-matter-embassy/src/ble.rs
+++ b/rs-matter-embassy/src/ble.rs
@@ -186,7 +186,10 @@ where
             let address: [u8; 6] = loop {
                 let addr = rand.next_u64() & 0x3f_ff_ff_ff_ff_ff;
                 if addr != 0 && addr != 0x3f_ff_ff_ff_ff_ff {
-                    break (addr | 0xc0_00_00_00_00_00).to_be_bytes()[2..]
+                    // A BLE BD_ADDR is little-endian, so its most-significant byte -- the
+                    // one that must carry the 0b11 static-random type bits -- is the last of
+                    // the six. Emit little-endian so the 0xc0 lands on address[5].
+                    break (addr | 0xc0_00_00_00_00_00).to_le_bytes()[..6]
                         .try_into()
                         .unwrap();
                 }


### PR DESCRIPTION
Fixes #53.

The BLE static random address was built with `to_be_bytes()`, placing the `0b11` type bits on `address[0]`. trouble-host treats `address[5]` as the BD_ADDR's most-significant byte, so the type bits landed on the wrong end and `address[5]` was left random — the controller rejected ~3/4 of generated addresses with `Invalid HCI Command Parameters`, failing to start the GATT peripheral and looping the firmware through reboots. Build the address little-endian so `0xc0` lands on `address[5]`.

Root-cause analysis, quantification, and the worked example are in #53.

Verified with `cargo fmt --check` and `cargo clippy --features log --no-deps -- -Dwarnings`; hardware-validated on ESP32-C6 (commissioning reboot loop gone).
