### PR TITLE
Compatibility with latest openthread

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,12 @@ rs-matter = { git = "https://github.com/sysgrok/rs-matter", branch = "next" }
 #rs-matter = { path = "../rs-matter/rs-matter" }
 rs-matter-stack = { git = "https://github.com/sysgrok/rs-matter-stack.git", branch = "next" }
 #rs-matter-stack = { path = "../rs-matter-stack" }
-openthread = { git = "https://github.com/sysgrok/openthread.git", branch = "next" }
+openthread = { git = "https://github.com/esp-rs/openthread" }
 #openthread = { path = "../../../openthread/openthread" }
+# The new edge-net (with `edge-nal-openthread` and embassy-net 0.9) is not released yet.
+edge-nal = { git = "https://github.com/sysgrok/edge-net" }
+edge-nal-embassy = { git = "https://github.com/sysgrok/edge-net" }
+edge-nal-openthread = { git = "https://github.com/sysgrok/edge-net" }
 nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "08620f00fa54e1423c4d54d2da073fb819602d27" }
 nrf-mpsl = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "08620f00fa54e1423c4d54d2da073fb819602d27" }
 nrf-802154 = { git = "https://github.com/sysgrok/nrf-802154" }

--- a/examples/esp/Cargo.toml
+++ b/examples/esp/Cargo.toml
@@ -39,8 +39,12 @@ rs-matter = { git = "https://github.com/sysgrok/rs-matter", branch = "next" }
 #rs-matter = { path = "../../../rs-matter/rs-matter" }
 rs-matter-stack = { git = "https://github.com/sysgrok/rs-matter-stack.git", branch = "next" }
 #rs-matter-stack = { path = "../../../rs-matter-stack" }
-openthread = { git = "https://github.com/sysgrok/openthread.git", branch = "next" }
+openthread = { git = "https://github.com/esp-rs/openthread" }
 #openthread = { path = "../../../openthread/openthread" }
+# The new edge-net (with `edge-nal-openthread` and embassy-net 0.9) is not released yet.
+edge-nal = { git = "https://github.com/sysgrok/edge-net" }
+edge-nal-embassy = { git = "https://github.com/sysgrok/edge-net" }
+edge-nal-openthread = { git = "https://github.com/sysgrok/edge-net" }
 #esp-radio = { path = "../../../esp-hal/esp-radio" }
 #esp-backtrace = { path = "../../../esp-hal/esp-backtrace" }
 #esp-hal = { path = "../../../esp-hal/esp-hal" }

--- a/examples/nrf/Cargo.toml
+++ b/examples/nrf/Cargo.toml
@@ -33,8 +33,12 @@ rs-matter = { git = "https://github.com/sysgrok/rs-matter", branch = "next" }
 #rs-matter = { path = "../../../rs-matter/rs-matter" }
 rs-matter-stack = { git = "https://github.com/sysgrok/rs-matter-stack.git", branch = "next" }
 #rs-matter-stack = { path = "../../../rs-matter-stack" }
-openthread = { git = "https://github.com/sysgrok/openthread.git", branch = "next" }
+openthread = { git = "https://github.com/esp-rs/openthread" }
 #openthread = { version = "0.1", path = "../../../openthread/openthread" }
+# The new edge-net (with `edge-nal-openthread` and embassy-net 0.9) is not released yet.
+edge-nal = { git = "https://github.com/sysgrok/edge-net" }
+edge-nal-embassy = { git = "https://github.com/sysgrok/edge-net" }
+edge-nal-openthread = { git = "https://github.com/sysgrok/edge-net" }
 nrf-sdc = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "08620f00fa54e1423c4d54d2da073fb819602d27" }
 nrf-mpsl = { git = "https://github.com/alexmoon/nrf-sdc.git", rev = "08620f00fa54e1423c4d54d2da073fb819602d27" }
 #nrf-802154 = { git = "https://github.com/sysgrok/nrf-802154" }

--- a/examples/rp/Cargo.toml
+++ b/examples/rp/Cargo.toml
@@ -29,8 +29,12 @@ rs-matter = { git = "https://github.com/sysgrok/rs-matter", branch = "next" }
 #rs-matter = { path = "../../../rs-matter/rs-matter" }
 rs-matter-stack = { git = "https://github.com/sysgrok/rs-matter-stack.git", branch = "next" }
 #rs-matter-stack = { path = "../../../rs-matter-stack" }
-openthread = { git = "https://github.com/sysgrok/openthread.git", branch = "next" }
+openthread = { git = "https://github.com/esp-rs/openthread" }
 #openthread = { version = "0.1", path = "../../../openthread/openthread" }
+# The new edge-net (with `edge-nal-openthread` and embassy-net 0.9) is not released yet.
+edge-nal = { git = "https://github.com/sysgrok/edge-net" }
+edge-nal-embassy = { git = "https://github.com/sysgrok/edge-net" }
+edge-nal-openthread = { git = "https://github.com/sysgrok/edge-net" }
 
 [features]
 skip-cyw43-firmware = []

--- a/rs-matter-embassy/Cargo.toml
+++ b/rs-matter-embassy/Cargo.toml
@@ -170,8 +170,9 @@ embassy-net = ["dep:embassy-net", "edge-nal-embassy", "openthread?/embassy-net-d
 esp = ["esp-radio", "esp-hal", "openthread?/esp-radio"]
 rp = ["cyw43", "cyw43-pio", "embassy-rp", "embassy-net-driver-channel"]
 nrf = ["embassy-nrf", "nrf-sdc", "nrf-mpsl", "nrf-802154", "portable-atomic", "openthread?/embassy-nrf"]
-log = ["dep:log", "rs-matter-stack/log", "openthread?/log", "embassy-net?/log", "edge-nal-embassy?/log", "trouble-host/log", "cyw43?/log"]
-defmt = ["dep:defmt", "rs-matter-stack/defmt", "openthread?/defmt", "embassy-net?/defmt", "edge-nal-embassy?/defmt", "trouble-host/defmt", "cyw43?/defmt", "cyw43-pio?/defmt"]
+openthread = ["dep:openthread", "dep:edge-nal-openthread"]
+log = ["dep:log", "rs-matter-stack/log", "openthread?/log", "edge-nal-openthread?/log", "embassy-net?/log", "edge-nal-embassy?/log", "trouble-host/log", "cyw43?/log"]
+defmt = ["dep:defmt", "rs-matter-stack/defmt", "openthread?/defmt", "edge-nal-openthread?/defmt", "embassy-net?/defmt", "edge-nal-embassy?/defmt", "trouble-host/defmt", "cyw43?/defmt", "cyw43-pio?/defmt"]
 rustcrypto = ["rs-matter-stack/rustcrypto"]
 mbedtls = ["rs-matter-stack/mbedtls"]
 
@@ -200,7 +201,6 @@ openthread-heap-int-65536 = ["openthread?/heap-int-65536"]
 log = { version = "0.4", default-features = false, optional = true }
 defmt = { version = "1", optional = true, features = ["ip_in_core"] }
 heapless = "0.9"
-heapless_08 = { package = "heapless", version = "0.8" } # For embassy-net 0.8
 enumset = { version = "1", default-features = false }
 embassy-futures = "0.1"
 embassy-sync = "0.8"
@@ -215,13 +215,14 @@ rand = { version = "0.8", default-features = false }
 embedded-storage-async = "0.4.1"
 sequential-storage = "3"
 
-embassy-net = { version = "0.8", optional = true }
+embassy-net = { version = "0.9", optional = true }
 edge-nal-embassy = { version = "0.8", optional = true, features = ["proto-ipv4", "proto-ipv6", "multicast", "dhcpv4", "medium-ethernet"] }
+edge-nal-openthread = { version = "0.1", optional = true, default-features = false }
 
 trouble-host = { version = "0.6", features = ["gatt"] }
 bt-hci = "0.8"
 
-openthread = { version = "0.1", optional = true, features = ["udp", "srp", "dns-client", "edge-nal", "force-generate-bindings"] }
+openthread = { version = "0.1", optional = true, features = ["udp", "srp", "dns-client", "force-generate-bindings"] }
 
 rand_core = "0.9"
 

--- a/rs-matter-embassy/src/enet.rs
+++ b/rs-matter-embassy/src/enet.rs
@@ -173,7 +173,7 @@ pub fn create_enet_config<D: Driver>(driver: &D) -> Config {
     config.ipv6 = ConfigV6::Static(StaticConfigV6 {
         address: Ipv6Cidr::new(create_link_local_ipv6(&mac), 10),
         gateway: None,
-        dns_servers: heapless_08::Vec::new(),
+        dns_servers: heapless::Vec::new(),
     });
 
     config

--- a/rs-matter-embassy/src/ot.rs
+++ b/rs-matter-embassy/src/ot.rs
@@ -134,7 +134,7 @@ impl<'d> OtNetStack<'d> {
 
 impl<'d> NetStack for OtNetStack<'d> {
     type UdpBind<'t>
-        = &'t OpenThread<'d>
+        = edge_nal_openthread::OtUdpStack<'d>
     where
         Self: 't;
 
@@ -159,7 +159,7 @@ impl<'d> NetStack for OtNetStack<'d> {
         Self: 't;
 
     fn udp_bind(&self) -> Option<Self::UdpBind<'_>> {
-        Some(&self.0)
+        Some(edge_nal_openthread::OtUdpStack::new(self.0.clone()))
     }
 
     fn udp_connect(&self) -> Option<Self::UdpConnect<'_>> {

--- a/rs-matter-embassy/src/ot.rs
+++ b/rs-matter-embassy/src/ot.rs
@@ -642,6 +642,7 @@ impl<'a, 'd> OtMdns<'a, 'd> {
                                 port: Some(info.port),
                                 addrs: core::iter::once(IpAddr::V6(addr)),
                                 txt: TxtEntries::new(info.txt_data.unwrap_or(&[])),
+                                scope_id: 0,
                             });
                     },
                 )
@@ -714,6 +715,7 @@ impl<'a, 'd> OtMdns<'a, 'd> {
                                 port: Some(info.port),
                                 addrs: core::iter::once(IpAddr::V6(addr)),
                                 txt: TxtEntries::new(info.txt_data.unwrap_or(&[])),
+                                scope_id: 0,
                             });
                     }
                 })


### PR DESCRIPTION
Latest `openthread` did remove the `edge-nal` UDP traits' implementation (or rather - moved those to a new `edge-nal-openthread` crate part of the `edge-net` project).