### PR TITLE
Add EspThreadDriver::with_rx_queue_size to tune the esp-radio RX queue depth

### DIFF
--- a/rs-matter-embassy/src/wireless/thread/esp_thread.rs
+++ b/rs-matter-embassy/src/wireless/thread/esp_thread.rs
@@ -12,6 +12,7 @@ use crate::wireless::SLOTS;
 pub struct EspThreadDriver<'d> {
     radio_peripheral: esp_hal::peripherals::IEEE802154<'d>,
     bt_peripheral: esp_hal::peripherals::BT<'d>,
+    rx_queue_size: Option<usize>,
 }
 
 impl<'d> EspThreadDriver<'d> {
@@ -26,7 +27,17 @@ impl<'d> EspThreadDriver<'d> {
         Self {
             radio_peripheral,
             bt_peripheral,
+            rx_queue_size: None,
         }
+    }
+
+    /// Override the esp-radio 802.15.4 receive-queue depth (frames buffered
+    /// before drops). Defaults to the `openthread` crate's default; raise it
+    /// (e.g. 200) for bursty Matter commissioning / SRP load.
+    #[must_use]
+    pub fn with_rx_queue_size(mut self, rx_queue_size: usize) -> Self {
+        self.rx_queue_size = Some(rx_queue_size);
+        self
     }
 }
 
@@ -38,6 +49,10 @@ impl super::ThreadDriver for EspThreadDriver<'_> {
         let radio = EspRadio::new(openthread::esp::Ieee802154::new(
             self.radio_peripheral.reborrow(),
         ));
+        let radio = match self.rx_queue_size {
+            Some(rx_queue_size) => radio.with_rx_queue_size(rx_queue_size),
+            None => radio,
+        };
 
         task.run(radio).await
     }
@@ -56,6 +71,10 @@ impl super::ThreadCoexDriver for EspThreadDriver<'_> {
         let radio = EspRadio::new(openthread::esp::Ieee802154::new(
             self.radio_peripheral.reborrow(),
         ));
+        let radio = match self.rx_queue_size {
+            Some(rx_queue_size) => radio.with_rx_queue_size(rx_queue_size),
+            None => radio,
+        };
 
         task.run(radio, ble_controller).await
     }


### PR DESCRIPTION
Plumbs the esp-radio RX-queue depth through `EspThreadDriver` so a firmware can set it without forking:

```rust
EspThreadDriver::new(radio, bt).with_rx_queue_size(200)
```

Defaults to the `openthread` crate's default (no behavior change). The `ThreadDriver`/`ThreadCoexDriver` build sites apply it inline (kept inline rather than a helper to preserve the disjoint-field borrow of `radio_peripheral` vs `bt_peripheral`).

**Why:** the large fragmented AddNOC/interview bursts during Matter-over-Thread commissioning overflow the default RX queue on ESP32-C6 (`Receive queue full`), dropping frames; raising the depth (e.g. 200) absorbs them.

> ⚠️ **Depends on esp-rs/openthread#91** (`EspRadio::with_rx_queue_size`). It won't compile against the released `openthread 0.2.0`, so **CI will fail until that lands and ships in a release** the dep resolves to. Opening as a draft for review/coordination. HW-validated end-to-end against the openthread branch (boot log shows the depth going 50 → 200; device commissions cleanly).

Background / discussion: esp-rs/openthread#92.
