### PR TITLE
Improve compatibility with Samsung SmartThings

### DIFF
--- a/rs-matter-embassy/src/wifi/esp.rs
+++ b/rs-matter-embassy/src/wifi/esp.rs
@@ -49,7 +49,7 @@ impl NetCtl for EspWifiController<'_> {
         info!("Wifi configuration updated for scanning");
 
         let mut scan_config = ScanConfig::default();
-        if let Some(network) = network {
+        if let Some(network) = network.filter(|n| !n.is_empty()) {
             scan_config = scan_config.with_ssid(core::str::from_utf8(network).unwrap_or("???"));
         }
 


### PR DESCRIPTION
Adjust SSID filtering to ignore empty string sent by Samsung SmartThings Android app version 1.8.47.24. This caused no WiFi networks to be reported back and the device pairing failed.

Fixes #63